### PR TITLE
Add support for Indic fonts (deva, gujr, knda, orya, etc)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ RUN apt-get update && apt-get -t jessie-backports -y install \
     ttf-wqy-zenhei \
     fonts-arphic-ukai \
     fonts-arphic-uming \
+    fonts-indic \
 && rm -rf /var/lib/apt/lists/*
 
 ENTRYPOINT /usr/bin/unoconv --listener --server=0.0.0.0 --port=2002


### PR DESCRIPTION
The package `fonts-indic` is a metapackage that includes fonts for several of the languages of India, see https://packages.debian.org/jessie/metapackages/fonts-indic

By having these installed, unoconv is able to convert all kinds of docs in these scripts.

According to the apt-get info message,
```
After this operation, 12.3 MB of additional disk space will be used.
```
the image size should only grow by ~12 MB as a result of this change.